### PR TITLE
Fix compile issues on recent versions of ESPHome

### DIFF
--- a/esphome/components/powerpal_ble/powerpal_ble.h
+++ b/esphome/components/powerpal_ble/powerpal_ble.h
@@ -5,9 +5,11 @@
 #include "esphome/components/esp32_ble_tracker/esp32_ble_tracker.h"
 #include "esphome/components/sensor/sensor.h"
 #include "esphome/core/defines.h"
+#include "esphome.h"
 #ifdef USE_HTTP_REQUEST
 #include "esphome/components/http_request/http_request.h"
 #include <ArduinoJson.h>
+#include <HTTPClient.h>
 #endif
 
 #ifdef USE_TIME
@@ -81,6 +83,10 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   void set_power_sensor(sensor::Sensor *power_sensor) { power_sensor_ = power_sensor; }
   void set_energy_sensor(sensor::Sensor *energy_sensor) { energy_sensor_ = energy_sensor; }
   void set_daily_energy_sensor(sensor::Sensor *daily_energy_sensor) { daily_energy_sensor_ = daily_energy_sensor; }
+  void set_cost_sensor(sensor::Sensor *cost_sensor) { cost_sensor_ = cost_sensor;}
+  void set_pulses_sensor(sensor::Sensor *pulses_sensor) { pulses_sensor_ = pulses_sensor;}
+  void set_watt_hours(sensor::Sensor *watt_hours_sensor) {watt_hours_sensor_ = watt_hours_sensor;}
+  void set_timestamp(sensor::Sensor *timestamp_sensor) { timestamp_sensor_ = timestamp_sensor;}
 #ifdef USE_HTTP_REQUEST
   void set_http_request(http_request::HttpRequestComponent *cloud_uploader) { cloud_uploader_ = cloud_uploader; }
 #endif
@@ -97,8 +103,8 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   void set_notification_interval(uint8_t reading_batch_size) { reading_batch_size_[0] = reading_batch_size; }
   void set_device_id(std::string powerpal_device_id) { powerpal_device_id_ = powerpal_device_id; }
   void set_apikey(std::string powerpal_apikey) { powerpal_apikey_ = powerpal_apikey; }
-  void set_energy_cost(float energy_cost) { energy_cost_ = energy_cost; }
-
+  void set_energy_cost(double energy_cost) { energy_cost_ = energy_cost; }
+  
  protected:
   std::string pkt_to_hex_(const uint8_t *data, uint16_t len);
   void decode_(const uint8_t *data, uint16_t length);
@@ -117,6 +123,10 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
   sensor::Sensor *power_sensor_{nullptr};
   sensor::Sensor *energy_sensor_{nullptr};
   sensor::Sensor *daily_energy_sensor_{nullptr};
+  sensor::Sensor *cost_sensor_{nullptr};
+  sensor::Sensor *pulses_sensor_{nullptr};
+  sensor::Sensor *watt_hours_sensor_{nullptr};
+  sensor::Sensor *timestamp_sensor_{nullptr};
 #ifdef USE_HTTP_REQUEST
   http_request::HttpRequestComponent *cloud_uploader_{nullptr};
 #endif
@@ -134,11 +144,10 @@ class Powerpal : public esphome::ble_client::BLEClientNode, public Component {
 
   uint8_t stored_measurements_count_{0};
   std::vector<PowerpalMeasurement> stored_measurements_;
-  // std::string powerpal_api_root_ = "http://192.168.1.167:1880/powerpal/";
-  std::string powerpal_api_root_ = "https://readings.powerpal.net/api/v1/meter_reading/";
+  std::string powerpal_api_root_ = "http://192.168.1.44:3000/";
   std::string powerpal_device_id_; // = "00002bc3";
   std::string powerpal_apikey_; // = "4a89e298-b17b-43e7-a0c1-fcd1412e98ef";
-  float energy_cost_;
+  double energy_cost_;
 
   uint16_t pairing_code_char_handle_ = 0x2e;
   uint16_t reading_batch_size_char_handle_ = 0x33;

--- a/esphome/components/powerpal_ble/sensor.py
+++ b/esphome/components/powerpal_ble/sensor.py
@@ -17,6 +17,7 @@ from esphome.const import (
     UNIT_WATT,
     UNIT_PERCENT,
     CONF_TIME_ID,
+    CONF_TEXT_SENSORS,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -35,7 +36,10 @@ CONF_COST_PER_KWH = "cost_per_kwh"
 CONF_POWERPAL_DEVICE_ID = "powerpal_device_id"
 CONF_POWERPAL_APIKEY = "powerpal_apikey"
 CONF_DAILY_ENERGY = "daily_energy"
-
+CONF_WATT_HOURS = "watt_hours"
+CONF_TIME_STAMP = "timestamp"
+CONF_PULSES = "pulses"
+CONF_COST = "cost"
 
 def _validate(config):
     if CONF_DAILY_ENERGY in config and CONF_TIME_ID not in config:
@@ -109,6 +113,12 @@ CONFIG_SCHEMA = cv.All(
                 device_class=DEVICE_CLASS_ENERGY,
                 state_class=STATE_CLASS_TOTAL_INCREASING,
             ),
+            cv.Optional(CONF_WATT_HOURS): sensor.sensor_schema(),
+            cv.Optional(CONF_PULSES): sensor.sensor_schema(),
+            cv.Optional(CONF_TIME_STAMP): sensor.sensor_schema(),
+            cv.Optional(CONF_COST): sensor.sensor_schema(
+                accuracy_decimals=11
+            ),
             cv.Required(CONF_PAIRING_CODE): cv.int_range(min=1, max=999999),
             cv.Required(CONF_NOTIFICATION_INTERVAL): cv.int_range(min=1, max=60),
             cv.Required(CONF_PULSES_PER_KWH): cv.float_range(min=1),
@@ -154,6 +164,22 @@ async def to_code(config):
     if CONF_DAILY_ENERGY in config:
         sens = await sensor.new_sensor(config[CONF_DAILY_ENERGY])
         cg.add(var.set_daily_energy_sensor(sens))
+
+    if CONF_PULSES in config:
+        sens = await sensor.new_sensor(config[CONF_PULSES])
+        cg.add(var.set_pulses_sensor(sens))
+
+    if CONF_WATT_HOURS in config:
+        sens = await sensor.new_sensor(config[CONF_WATT_HOURS])
+        cg.add(var.set_watt_hours(sens))
+
+    if CONF_TIME_STAMP in config:
+        sens = await sensor.new_sensor(config[CONF_TIME_STAMP])
+        cg.add(var.set_timestamp(sens))
+
+    if CONF_COST in config:
+        sens = await sensor.new_sensor(config[CONF_COST])
+        cg.add(var.set_cost_sensor(sens))
 
     if CONF_PAIRING_CODE in config:
         cg.add(var.set_pairing_code(config[CONF_PAIRING_CODE]))


### PR DESCRIPTION
# What does this implement/fix?

Fixes compile errors on ESPHome 2022.11.3. Since the cloud upload wasn't working using the http_request component, I've added sensors to expose cost, timestamp, pulses and watt_hours which can then be uploaded using HA native REST commands.

Create a new folder called 'my_components' under esphome in your /config directory. Add folder powerpal_ble from [here](https://github.com/muneeb1990/esphome/tree/powerpal_ble/esphome/components/powerpal_ble). 

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

**Related issue or feature (if applicable):** fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):** esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266

## Example entry for `config.yaml`:
```
### for upload to Powerpal cloud (optional)
rest_command:
  my_request:
    url: https://readings.powerpal.net/api/v1/meter_reading/<powerpal_device_id>
    method: POST
    headers:
      authorization: "<powerpal_apikey>"
      accept: ""
    payload: >-
       [ {"cost":{{ states.sensor.powerpal_cost_json.state }},"is_peak": false, "pulses":{{ states.sensor.powerpal_pulses_json.state }}, "timestamp": {{ (int(states.sensor.powerpal_timestamp_json.state)//60) * 60 }}, "watt_hours": {{ states.sensor.powerpal_watt_hours_json.state}} } ]
    content_type: 'application/json'
    verify_ssl: true
```

## Example `powerpal.yaml`
```
esphome:
  name: "esp32-powerpal"

esp32:
  board: esp32dev

external_components:
  - source:
      type: local
      path: my_components
    components: [powerpal_ble]
# Enable logging
logger:
 level: VERY_VERBOSE
 logs:
  esp32_ble_tracker: WARN
# Enable Home Assistant API
api:

ota:

#esp32_ble_tracker:

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

# optional requirement used with daily energy sensor
time:
  - platform: homeassistant
    id: homeassistant_time

esp32_ble_tracker:

ble_client:
  - mac_address: XX:XX:XX:XX:XX:XX #replace with your Powerpal device MAC
    id: powerpal

#http_request:
 #id: powerpal_cloud_uploader

switch:
  - platform: restart
    name: "Powerpal Monitor Reboot"

sensor:
  - platform: powerpal_ble
    ble_client_id: powerpal
    power:
      name: "Powerpal Power"
    daily_energy:
      name: "Powerpal Daily Energy"
    energy:
      name: "Powerpal Total Energy"
    battery_level:
      name: "Powerpal Battery"
    watt_hours:
       name: "Powerpal Watt Hours_json"
    cost:
       name: "Powerpal Cost_json"
    timestamp:
       name: "Powerpal Timestamp_json"
    pulses:
       name: "Powerpal Pulses_json"
    pairing_code: 123456 #add your pairing code
    notification_interval: 1
    pulses_per_kwh: 1000
    #http_request_id: powerpal_cloud_uploader
    time_id: homeassistant_time # daily energy still works without a time_id, but recommended to include one to properly handle daylight savings, etc.
    cost_per_kwh: 0.1843 #dollars per kWh
    
    #powerpal_device_id:  #optional, component will retrieve from your Powerpal if not set
    #powerpal_apikey:  #optional, component will retrieve from your Powerpal if not set
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
