### PR TITLE
Fix Powerpal Readings API sensors

### DIFF
--- a/esphome/components/powerpal_ble/powerpal_ble.cpp
+++ b/esphome/components/powerpal_ble/powerpal_ble.cpp
@@ -78,7 +78,7 @@ void Powerpal::parse_measurement_(const uint8_t *data, uint16_t length) {
     }
 
     if (this->watt_hours_sensor_ != nullptr) {
-      int mywatt_hrs = ((float)pulses_within_interval) / (this->pulses_per_kwh_ / kw_to_w_conversion);
+       float mywatt_hrs = ((float)pulses_within_interval) / (this->pulses_per_kwh_ / kw_to_w_conversion);
        this->watt_hours_sensor_->publish_state(mywatt_hrs);
     }
      if (this->timestamp_sensor_ != nullptr) {

--- a/esphome/components/powerpal_ble/powerpal_ble.cpp
+++ b/esphome/components/powerpal_ble/powerpal_ble.cpp
@@ -78,7 +78,7 @@ void Powerpal::parse_measurement_(const uint8_t *data, uint16_t length) {
     }
 
     if (this->watt_hours_sensor_ != nullptr) {
-      int mywatt_hrs = (uint32_t)roundf(pulses_within_interval * (this->pulses_per_kwh_ / kw_to_w_conversion));
+      int mywatt_hrs = (uint32_t)roundf(((float)pulses_within_interval) / (this->pulses_per_kwh_ / kw_to_w_conversion));
        this->watt_hours_sensor_->publish_state(mywatt_hrs);
     }
      if (this->timestamp_sensor_ != nullptr) {

--- a/esphome/components/powerpal_ble/powerpal_ble.cpp
+++ b/esphome/components/powerpal_ble/powerpal_ble.cpp
@@ -78,7 +78,7 @@ void Powerpal::parse_measurement_(const uint8_t *data, uint16_t length) {
     }
 
     if (this->watt_hours_sensor_ != nullptr) {
-      int mywatt_hrs = (uint32_t)roundf(((float)pulses_within_interval) / (this->pulses_per_kwh_ / kw_to_w_conversion));
+      int mywatt_hrs = ((float)pulses_within_interval) / (this->pulses_per_kwh_ / kw_to_w_conversion);
        this->watt_hours_sensor_->publish_state(mywatt_hrs);
     }
      if (this->timestamp_sensor_ != nullptr) {

--- a/esphome/components/powerpal_ble/powerpal_ble.h
+++ b/esphome/components/powerpal_ble/powerpal_ble.h
@@ -25,7 +25,7 @@ namespace espbt = esphome::esp32_ble_tracker;
 struct PowerpalMeasurement {
   uint16_t pulses;
   time_t timestamp;
-  uint32_t watt_hours;
+  float watt_hours;
   float cost;
   // bool is_peak;
 };

--- a/esphome/components/powerpal_ble/sensor.py
+++ b/esphome/components/powerpal_ble/sensor.py
@@ -110,7 +110,11 @@ CONFIG_SCHEMA = cv.All(
                 device_class=DEVICE_CLASS_ENERGY,
                 state_class=STATE_CLASS_TOTAL_INCREASING,
             ),
-            cv.Optional(CONF_WATT_HOURS): sensor.sensor_schema(),
+            cv.Optional(CONF_WATT_HOURS): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT,
+                accuracy_decimals=4,
+                device_class=DEVICE_CLASS_ENERGY,
+            ),
             cv.Optional(CONF_PULSES): sensor.sensor_schema(),
             cv.Optional(CONF_DAILY_PULSES): sensor.sensor_schema(),
             cv.Optional(CONF_TIME_STAMP): sensor.sensor_schema(),

--- a/esphome/components/powerpal_ble/sensor.py
+++ b/esphome/components/powerpal_ble/sensor.py
@@ -14,6 +14,7 @@ from esphome.const import (
     STATE_CLASS_MEASUREMENT,
     STATE_CLASS_TOTAL_INCREASING,
     UNIT_KILOWATT_HOURS,
+    UNIT_WATT_HOURS,
     UNIT_WATT,
     UNIT_PERCENT,
     CONF_TIME_ID,
@@ -111,7 +112,7 @@ CONFIG_SCHEMA = cv.All(
                 state_class=STATE_CLASS_TOTAL_INCREASING,
             ),
             cv.Optional(CONF_WATT_HOURS): sensor.sensor_schema(
-                unit_of_measurement=UNIT_WATT,
+                unit_of_measurement=UNIT_WATT_HOURS,
                 accuracy_decimals=4,
                 device_class=DEVICE_CLASS_ENERGY,
             ),


### PR DESCRIPTION
I was getting astronomical figures reported to Powerpal Cloud!

Turned out the "Watt Hours" sensor was off by a factor of my meter pulse rate (3.200) squared. After some quick algebra I realised the calculation inside this module was incorrect.

For reference, my `rest_command` looks like this:

```yaml
rest_command:
  send_readings_to_powerpal_cloud:
    url: "https://readings.powerpal.net/api/v1/meter_reading/{{POWERPAL_DEVICE_ID}}"
    method: POST
    headers:
      authorization: "{{POWERPAL_API_KEY}}"
      accept: ""
    payload: >-
       {% set readings = [{
            "is_peak": false, 
            "pulses": states('sensor.powerpal_pulses') | int, 
            "timestamp": now() | as_timestamp | int // 60 * 60,
            "watt_hours": states('sensor.powerpal_watt_hours') | float
        }] %}
        {{ readings | to_json }}
    content_type: 'application/json'
    verify_ssl: true
``` 

and I have an automation that kicks off for each change to the "Daily Pulses" sensor:

```yaml
alias: PowerPal - Send Readings to Cloud
description: ""
triggers:
  - trigger: state
    entity_id:
      - sensor.powerpal_daily_pulses
    from: null
    enabled: true
conditions: []
actions:
  - action: rest_command.send_readings_to_powerpal_cloud
    metadata: {}
    data: {}
    response_variable: api_response
mode: single
```

Interestingly, I noticed that the "Powerpal Timestamp" sensor only seems to update every 2-3 minutes, instead of every minute. It appears that while a set of values _is_ produced every minute, sometimes the timestamp in the BLE packet doesn't change, so in my automation I have just used `now() | as_timestamp | int // 60 * 60`, which seems to do the trick.